### PR TITLE
JCN settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Changed
+- path for `.janniscommercerc.json`, to `[MS_PATH]/config`
+
 ## [1.0.0] - 2019-07-04
 ### Added
 - `README`

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 ## Installation
 ```bash
-npm install janiscommerce/settings
+npm install @janiscommerce/settings
 ```
 
 ## API

--- a/README.md
+++ b/README.md
@@ -19,6 +19,11 @@ npm install @janiscommerce/settings
 
 The setting file is a JSON with all the settings.
 
+It's located in `path/to/root/[MS_PATH]/config/.janiscommercerc.json`.
+
+`[MS_PATH]` : ENV variable. Default is empty.
+
+
 ### Example
 ```json
 {

--- a/lib/index.js
+++ b/lib/index.js
@@ -6,7 +6,7 @@ class Settings {
 
 	static get configPath() {
 		const prefix = typeof process.env.MS_PATH === 'string' ? process.env.MS_PATH : '';
-		return path.join(process.cwd(), prefix, '.janiscommercerc.json');
+		return path.join(process.cwd(), prefix, 'config', '.janiscommercerc.json');
 	}
 
 	static _setCache() {

--- a/tests/settings-test.js
+++ b/tests/settings-test.js
@@ -102,13 +102,13 @@ describe('Settings', () => {
 
 	it('should use MS_PATH as prefix when exists', () => {
 		process.env.MS_PATH = 'my-prefix';
-		assert(Settings.configPath.endsWith('/my-prefix/.janiscommercerc.json'));
+		assert(Settings.configPath.endsWith('my-prefix/config/.janiscommercerc.json'));
 	});
 
 	it('should use MS_PATH as prefix when not exists', () => {
 		// settings/ cause is the folder of the package
 		// configPath getter use process.cwd()
-		assert(Settings.configPath.endsWith('/settings/.janiscommercerc.json'));
+		assert(Settings.configPath.endsWith('settings/config/.janiscommercerc.json'));
 	});
 
 });


### PR DESCRIPTION
**PAQUETE SETTINGS**
JCN Paquete npm Settings

**DESCRIPCIÓN DEL REQUERIMIENTO**
1.1 - Corrección del path para el archivo `.janiscommercerc.json`

**DESCRIPCIÓN DE LA SOLUCIÓN**
Se cambió el path del archivo `.janiscommercerc.json`. 
Se corrigieron los Unit test.
Se corrigió el *README*, faltaba agregarle el scope(correcto) en la sección de instalación.